### PR TITLE
Removed CMAKE_EXPORT_COMPILE_COMMANDS option

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
           mkdir -p build;
           cd build;
 
-          cmake -DBUILD_SAMPLE=ON -DCMAKE_INSTALL_PREFIX=installation -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -G Ninja ..;
+          cmake -DBUILD_SAMPLE=ON -DCMAKE_INSTALL_PREFIX=installation -G Ninja ..;
           cmake --build . -- -j8;
         '''
         recordIssues enabledForFailure: true, qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [clangTidy()]


### PR DESCRIPTION
No need to generate compiler database, since setting
CMALE_CXX_CLANG_TIDY will do it for us.

Signed-off-by: Nikita Vakula <programmistov.programmist@gmail.com>